### PR TITLE
Recover Soil when emptying planters

### DIFF
--- a/VisualStudio/IGButtons.cs
+++ b/VisualStudio/IGButtons.cs
@@ -329,24 +329,29 @@ namespace IndoorsGreenery
         }
         private static void OnEmptyRecipientFinished(bool success, bool playerCancel, float progress)
         {
-            HUDMessage.AddMessage(Localization.Get("GAMEPLAY_IG_SoilLost"));
+            //HUDMessage.AddMessage(Localization.Get("GAMEPLAY_IG_SoilLost"));
             if (soilItemName == "GEAR_DirtCan")
             {
                 GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.recipientItem1, 1);
+                GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.soilBag, 1);
             }
             else if (soilItemName == "GEAR_DirtPot")
             {
                 GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.recipientItem2, 1);
+                GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.soilBag, 2);
             }
             else if (soilItemName == "GEAR_DirtHumid")
             {
                 GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.recipientItem3, 1);
+                GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.soilBag, 3);
             }
             else
             {
                 GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.recipientItem4, 1);
+                GameManager.GetPlayerManagerComponent().InstantiateItemInPlayerInventory(IGUtils.soilBag, 3);
             }
 
         }
     }
 }
+


### PR DESCRIPTION
Seeing a soil is non-renewable and there isn't a whole lot of it, it think it makes sense to recover it when emptying a planter.

For example, I play on Interloper and so far I have only found 10 bags of soil. If I make a couple small planters and then I want to swap to a box or humid planter later on, I would have to find more dirt.